### PR TITLE
fix casing error causing build error

### DIFF
--- a/src/templates/issue-page.js
+++ b/src/templates/issue-page.js
@@ -1,7 +1,7 @@
 import React from 'react'
 import { FormattedMessage } from "react-intl";
 import Layout from '../components/Layout'
-import PageUnderNavbar from '../components/PageUnderNavbar'
+import PageUnderNavbar from '../components/PageUnderNavBar'
 import Issue from '../components/Issue'
 import { oneLine } from "../translations/stringFileUtils";
 import { localizedStringsKeypaths } from "../translations/es";


### PR DESCRIPTION
Macs apparently are case insensitive when evaluating file names, so we were able to build fine locally, but this was causing an error when I tried to build on netlify